### PR TITLE
Add bfactor module

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -29,6 +29,7 @@ import click
 @click.option("--strip_all", "-sa", is_flag=True, help="Strip waters and metals.")
 @click.option("--dssp_plot", "-dp", is_flag=True, help="Generate a DSSP plot.")
 @click.option("--calculate_rmsf", "-cf", is_flag=True, help="Calculate the RMSF.")
+@click.option("--add_bfactor", "-bf", is_flag=True, help="Adds data as the b-factor for a PDB file.")
 @click.help_option('--help', '-h', is_flag=True, help='Exiting pyQMMM.')
 def md(
     gbsa_submit,
@@ -42,6 +43,7 @@ def md(
     strip_all,
     dssp_plot,
     calculate_rmsf,
+    add_bfactor,
     ):
     """
     Functions for molecular dynamics (MD) simulations.
@@ -146,6 +148,12 @@ def md(
             "../../3_md/7/1_output/constP_prod.crd",
         ]
         pyqmmm.md.rmsf_calculator.calculate_rmsf(topology, trajectories, reference)
+
+    elif add_bfactor:
+        click.echo("> Adds values from a csv as the bfactor data of a PDB:")
+        click.echo("> Loading...")
+        import pyqmmm.md.bfactor_adder
+        pyqmmm.md.bfactor_adder.add_bfactor()
 
 
 @click.command()

--- a/pyqmmm/md/bfactor_adder.py
+++ b/pyqmmm/md/bfactor_adder.py
@@ -1,0 +1,66 @@
+import os
+import pandas as pd
+import glob
+
+def get_filenames():
+    """
+    Identify the only .csv and .pdb files in the current directory.
+
+    Returns
+    -------
+    tuple
+        The names of the identified .csv and .pdb files.
+    """
+    csv_files = glob.glob('*.csv')
+    if len(csv_files) != 1:
+        raise FileNotFoundError(f'Expected one .csv file in the current directory, found {len(csv_files)}')
+    
+    pdb_files = glob.glob('*.pdb')
+    if len(pdb_files) != 1:
+        raise FileNotFoundError(f'Expected one .pdb file in the current directory, found {len(pdb_files)}')
+
+    return csv_files[0], pdb_files[0]
+
+def process_and_write_pdb(csv_file, pdb_file):
+    """
+    Update the b-factors in a pdb file and write to a new file using data from a .csv file.
+
+    Parameters
+    ----------
+    csv_file : str
+        The name of the .csv file to read b-factor data from.
+    pdb_file : str
+        The name of the .pdb file to update.
+    """
+    # Get the b-factor data
+    df = pd.read_csv(csv_file)
+    b_factors = df.iloc[:, -1].tolist()  # Get the last column values
+
+    # Process the pdb file and write to a new file
+    with open(pdb_file, 'r') as pdb_file_obj, open('new_'+pdb_file, 'w') as new_pdb_file:
+        for line in pdb_file_obj:
+            if line.startswith(('ATOM', 'HETATM')):
+                residue_number = int(line[22:26].strip())
+                if residue_number <= len(b_factors):
+                    b_factor = round(b_factors[residue_number - 1], 2)  # Round the b-factor to 2 decimal places
+                    new_line = line[:60] + '{:6.2f}'.format(b_factor) + line[66:]
+                    new_pdb_file.write(new_line)
+                else:
+                    new_pdb_file.write(line)
+            else:
+                new_pdb_file.write(line)
+
+def add_bfactor():
+    """
+    Main function to execute the script.
+    """
+    csv_file, pdb_file = get_filenames()
+    print('Using CSV file: {}'.format(csv_file))
+    print('Using PDB file: {}'.format(pdb_file))
+
+    process_and_write_pdb(csv_file, pdb_file)
+
+    print('New PDB file with updated B-factors has been saved as new_'+pdb_file)
+
+if __name__ == "__main__":
+    add_bfactor()


### PR DESCRIPTION
I wrote a new module that reads in a protein PDB file and adds b-factor data to all atoms by residue and saves it out as a new PDB file. The script overwrites any existing b-factor entry in the PDB file and adds it if there is no b-factor data. The data that is added comes from the only .csv file that is in the current directory. The module identifies any .csv file and reports its name to the user in case the wrong one was identified. The .csv file can have an arbitrary number of columns but the last column is fetched to be compatible with the RMSD and RMSF modules. Each row corresponds to the value for an amino acid in the PDB. For example, if the PDB has 100 amino acids than the .csv will have 101 rows, one for each amino acid and a header row. The value corresponding to each residue from the last column of csv is added as the new b-factor value for every atom corresponding to that amino acid. The entries in the csv are in the same order as the amino acids in the PDB. Also, I assumed that a user will want the B-factors recorded in columns 61-66 of each line that starts with "ATOM" or "HETATM as is the convention.