### PR TITLE
Added a script for analyzing residue decomposition

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -28,6 +28,7 @@ import click
 @click.option("--restraint_plot", "-rp", is_flag=True, help="Restraint plot KDE's on one plot.")
 @click.option("--strip_all", "-sa", is_flag=True, help="Strip waters and metals.")
 @click.option("--dssp_plot", "-dp", is_flag=True, help="Generate a DSSP plot.")
+@click.option("--residue_decomp", "-rd", is_flag=True, help="Analyze residue decomposition analysis.")
 @click.help_option('--help', '-h', is_flag=True, help='Exiting pyQMMM.')
 def md(
     gbsa_submit,
@@ -40,6 +41,7 @@ def md(
     restraint_plot,
     strip_all,
     dssp_plot,
+    residue_decomp,
     ):
     """
     Functions for molecular dynamics (MD) simulations.
@@ -127,6 +129,12 @@ def md(
         import pyqmmm.md.dssp_plotter
         pyqmmm.md.dssp_plotter.combine_dssp_files()
 
+    if residue_decomp:
+        click.echo("> Analyze residue decomposition jobs:")
+        click.echo("> Loading...")
+        import pyqmmm.qm.residue_decomposition
+        pyqmmm.qm.residue_decomposition.residue_decomposition()
+
 
 @click.command()
 @click.option("--plot_energy", "-pe", is_flag=True, help="Plot the energy of a xyz traj.")
@@ -161,7 +169,6 @@ def qm(
         import pyqmmm.qm.mechanism_plotter
         color_scheme = input("What color scheme would you like (e.g., tab20, viridis)? ")
         pyqmmm.qm.mechanism_plotter.generate_plot(color_scheme)
-
 
 if __name__ == "__main__":
     # Run the command-line interface when this script is executed

--- a/pyqmmm/qm/residue_decomposition.py
+++ b/pyqmmm/qm/residue_decomposition.py
@@ -1,0 +1,118 @@
+"""Extract and compare energies from a residue decomposition analysis"""
+
+import os
+import re
+import pandas as pd
+import matplotlib.pyplot as plt
+
+def natural_sort(s):
+    return [int(text) if text.isdigit() else text.lower()
+            for text in re.split(r'(\d+)', s)]
+
+def get_energy(filename):
+    final_energy = None
+    with open(filename, 'r') as file:
+        for line in file:
+            if "FINAL ENERGY:" in line:
+                final_energy = float(line.split()[2])
+    return final_energy
+
+def process_directory(path, ignore):
+    energies = {}
+    paths_to_process = []
+    for root, dirs, files in os.walk(path):
+        if 'qmscript.out' in files and os.path.basename(root) not in ignore:
+            paths_to_process.append(root)
+            
+    for path in paths_to_process:
+        dir_name = os.path.basename(path)
+        energy = get_energy(os.path.join(path, 'qmscript.out'))
+        if energy:
+            energies[dir_name] = energy
+    return energies
+
+def plot_data(df):
+    color_codes = [
+        "#FF5733",  # Bright Red Orange
+        "#8AD7A5",  # Soft Mint Green
+        "#FFD700",  # Golden Yellow
+        "#6B2C91",  # Deep Violet
+        "#4A8F79",  # Vintage Teal
+        "#F08080",  # Light Coral
+        "#50B4B7",  # Aqua Marine
+        "#8B7765",  # Antique Bronze
+        "#6D9EEB",  # Dodger Blue
+        "#C27BA0",  # Antique Fuchsia
+        "#1D2951",  # Oxford Blue
+        "#F4D03F",  # Naples Yellow
+        "#64C4ED",  # Baby Blue Eyes
+        "#E67F83",  # English Vermillion
+        "#D99058"   # Lion
+    ]
+    fig, ax = plt.subplots()
+    ax.axhline(0, color='grey', linewidth=1.5, zorder=1)  # Increased linewidth to 1.5
+
+    for i, (index, row) in enumerate(df.iterrows()):
+        legend_label = index.split('_')[1] if '_' in index else index
+        if legend_label == 'all':
+            ax.plot(row.index, row, label=legend_label, color='black', linewidth=2, zorder=3)  # Draw 0_all trace as bold black line
+        else:
+            ax.plot(row.index, row, label=legend_label, color=color_codes[i % len(color_codes)], zorder=2)
+            
+    # Position the legend outside the plot on the right-hand side
+    ax.legend(bbox_to_anchor=(1.05, 1), loc='upper left')
+    ax.set_xlabel('pathway intermediate', weight="bold")
+    ax.set_ylabel('relative energy (kcal/mol)', weight="bold")
+    plt.xticks(rotation=90)
+    plt.tight_layout()
+    plt.savefig('energies_plot.svg', bbox_inches='tight')
+    plt.savefig('energies_plot.png', dpi=300, bbox_inches='tight')
+
+def format_plot() -> None:
+    """
+    General plotting parameters for the Kulik Lab.
+
+    """
+    font = {"family": "sans-serif", "weight": "bold", "size": 10}
+    plt.rc("font", **font)
+    plt.rcParams["xtick.major.pad"] = 5
+    plt.rcParams["ytick.major.pad"] = 5
+    plt.rcParams["axes.linewidth"] = 2
+    plt.rcParams["xtick.major.size"] = 7
+    plt.rcParams["xtick.major.width"] = 2
+    plt.rcParams["ytick.major.size"] = 7
+    plt.rcParams["ytick.major.width"] = 2
+    plt.rcParams["xtick.direction"] = "in"
+    plt.rcParams["ytick.direction"] = "in"
+    plt.rcParams["xtick.top"] = True
+    plt.rcParams["ytick.right"] = True
+    plt.rcParams["svg.fonttype"] = "none"
+
+def residue_decomposition():
+    ignore = ['0_prep']
+    kcal_per_hartree = 627.509  # Replace with the correct conversion factor
+
+    base_path = './'  # Replace with the correct path to the base directory
+    data = {}
+    for folder_name in sorted(os.listdir(base_path), key=natural_sort):
+        if folder_name in ignore:
+            continue
+        folder_path = os.path.join(base_path, folder_name)
+        if os.path.isdir(folder_path):
+            data[folder_name] = process_directory(folder_path, ignore)
+
+    df = pd.DataFrame(data)
+    df = df.applymap(lambda x: x * kcal_per_hartree if pd.notnull(x) else x)
+    
+    # Make energies relative to the first energy in each row
+    df = df.subtract(df.iloc[:, 0], axis=0)
+
+    # Remove prefix from column names for x-axis labels
+    df.columns = [name.split('_')[1] if '_' in name else name for name in df.columns]
+
+    format_plot()
+    plot_data(df)
+    df.to_csv('energies.csv')
+
+if __name__ == '__main__':
+    residue_decomposition()


### PR DESCRIPTION
I created a Python script that parses energy data from multiple directory levels, constructs a pandas DataFrame from this data, performs some calculations, and generates a visual plot using matplotlib. The script reads data from multiple directories and subdirectories. The directories and subdirectories are expected to be named in numerical order like '1_R', '2_IM1', '3_IM_TS', etc., which correspond to DataFrame columns, and the rows are determined by the subdirectories in each top-level directory.

Directories named '0_prep' will be ignored but other directories can be added to the list of directories to ignore. In each subdirectory, the script opens a file named 'qmscript.out', which is the TeraChem output. It will parse the last instance of 'FINAL ENERGY:' in this file, which is followed by a floating-point energy value in atomic units (a.u.). This energy value is then recorded in the appropriate cell of the DataFrame. After reading all energy values, the DataFrame are updated so that all energy values are relative to the first value in each row. The values are converted from hartrees to kcal/mol using a conversion factor of 627.509 kcal/mol. The completed DataFrame is saved to a CSV file named 'energies.csv'.

Using matplotlib, the script generates a plot with the relative energies on the y-axis and the different points in each row (i.e., pathway intermediates) on the x-axis. Each row from the DataFrame is plotted as a separate trace with a unique color from the Tab20 color scheme with the '0_all' trace in bold black. The x-axis labels come from the column names but only include the part after the underscore '_'. A horizontal line is drawn at y = 0. The plot is saved in both SVG and PNG formats with a resolution of 300 dpi for the PNG.
