### PR TITLE
Add custom colors

### DIFF
--- a/pyqmmm/qm/residue_decomposition.py
+++ b/pyqmmm/qm/residue_decomposition.py
@@ -98,14 +98,20 @@ def plot_data(df):
         "#4A8F79",  # Vintage Teal
         "#F08080",  # Light Coral
         "#50B4B7",  # Aqua Marine
-        "#8B7765",  # Antique Bronze
+        "#A9A9A9",  # Dark Gray
         "#6D9EEB",  # Dodger Blue
         "#C27BA0",  # Antique Fuchsia
         "#1D2951",  # Oxford Blue
         "#F4D03F",  # Naples Yellow
         "#64C4ED",  # Baby Blue Eyes
         "#E67F83",  # English Vermillion
-        "#D99058",   # Lion
+        "#D99058",  # Lion
+        "#228B22",  # Forest Green
+        "#FF69B4",  # Bright Pink
+        "#32CD32",  # Lime Green
+        "#4169E1",  # Royal Blue
+        "#DC143C",  # Crimson
+        "#D2691E",  # Chocolate Brown
     ]
     fig, ax = plt.subplots()
     ax.axhline(0, color='silver', linewidth=1.5, zorder=1)  # Increased linewidth to 1.5


### PR DESCRIPTION
For the energy decomposition analysis script, I had previously spent a lot of time custom building a color theme that was both attractive and where every color was distinguishable. My goal was to maximize coordination as well as contrast. In this newest update to the color scheme I added 5 new colors giving the user the ability to simultaneously compare 20 traces with different colors. This is not a pleasant experience using the matplotlib default color schemes.