### PR TITLE
Add mdanalysis to conda env

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,6 +11,7 @@ dependencies:
   - cookiecutter
   - click
   - matplotlib
+  - mdanalysis
   - modeller
   - numpy
   - pandas


### PR DESCRIPTION
Added MDAnalysis to the environment yaml to make it part of the default environment.