### PR TITLE
Add script for preparing ORCA NEB jobs

### DIFF
--- a/pyqmmm/cli.py
+++ b/pyqmmm/cli.py
@@ -206,6 +206,7 @@ def md(
 @click.option("--qm_replace_pdb", "-qr", is_flag=True, help="Replace QM optimized atoms in a pdb.")
 @click.option("--bond_valence", "-bv", is_flag=True, help="Replace QM optimized atoms in a pdb.")
 @click.option("--orca_scan", "-os", is_flag=True, help="Plots an ORCA scan.")
+@click.option("--orca_neb_restart", "-rneb", is_flag=True, help="Prepare to restart an ORCA NEB.")
 @click.help_option('--help', '-h', is_flag=True, help='Exiting pyQMMM.')
 def qm(
     plot_energy,
@@ -215,6 +216,7 @@ def qm(
     qm_replace_pdb,
     bond_valence,
     orca_scan,
+    orca_neb_restart,
     ):
     """
     Functions for quantum mechanics (QM) simulations.
@@ -279,6 +281,12 @@ def qm(
         distances, relative_energies = pyqmmm.qm.orca_scan_plotter.read_orca_output("orca.out")
         print(f"   > Start distance: {distances[0]}, End distance: {distances[-1]}\n")
         pyqmmm.qm.orca_scan_plotter.plot_energy(distances, relative_energies, atom_1, atom_2)
+
+    if orca_neb_restart:
+        import pyqmmm.qm.orca_restart_prepare
+        pyqmmm.qm.orca_neb_restart.create_delete_folder()
+        files_in_directory = [f for f in os.listdir() if f != 'delete']
+        pyqmmm.qm.orca_neb_restart.move_files(files_in_directory)
 
 if __name__ == "__main__":
     # Run the command-line interface when this script is executed

--- a/pyqmmm/md/gbsa_analyzer.py
+++ b/pyqmmm/md/gbsa_analyzer.py
@@ -183,7 +183,10 @@ def plot_single_total_gbsa(df, file_name) -> None:
     ax = df.plot.bar(x="Residue", y="Total", color=colors, figsize=(4, 4))
     ax.set_ylabel("GBSA energy (kcal/mol)", weight="bold")
     ax.set_xlabel("residue", weight="bold")
-    plt.savefig(file_name, bbox_inches="tight", transparent=True)
+    
+    extensions = ["png", "svg"]
+    for ext in extensions:
+        plt.savefig(f"{file_name}.{ext}", bbox_inches="tight", format=ext, transparent=True)
     plt.close()
 
 
@@ -255,7 +258,10 @@ def plot_all_gbsa(df_hits, y_columns, sorted_x_labels) -> None:
         y_columns,
         sorted_x_labels,
     )
-    plt.savefig("stacked_single.svg", bbox_inches="tight", transparent=True)
+
+    extensions = ["png", "svg"]
+    for ext in extensions:
+        plt.savefig(f"stacked_single.{ext}", bbox_inches="tight", format=ext, transparent=True)
 
 
 def analyze() -> None:
@@ -301,7 +307,7 @@ def analyze() -> None:
     df_hits = get_top_hits_df(df, sub_num, num_hits, sorted_x_labels)
 
     # Plot GBSA Total
-    plot_single_total_gbsa(df_hits, "gbsa_total.svg")
+    plot_single_total_gbsa(df_hits, "gbsa_total")
 
     # Plot All GBSA
     plot_all_gbsa(df_hits, ["VDW", "Electrostatic", "Polar", "Non-polar"], sorted_x_labels)

--- a/pyqmmm/md/hbond_analyzer.py
+++ b/pyqmmm/md/hbond_analyzer.py
@@ -256,7 +256,10 @@ def plot(data, file_path):
     ax.set_xlabel("residue", weight="bold")
     ax.legend().set_visible(False)
     ax.tick_params(axis="x", labelrotation=90)
-    plt.savefig(file_path + "hbond.svg", format="svg", dpi=600, bbox_inches="tight")
+
+    extensions = ["png", "svg"]
+    for ext in extensions:
+        plt.savefig(file_path + f"hbond.{ext}", format=ext, dpi=600, bbox_inches="tight")
 
 
 def plot_multi(data, file_path):
@@ -282,12 +285,16 @@ def plot_multi(data, file_path):
     ax.set_xlabel("residue", weight="bold")
     ax.legend(bbox_to_anchor=(1.34, 1.02), frameon=False)
     ax.tick_params(axis="x", labelrotation=90)
-    plt.savefig(
-        file_path + "hbond_comparison.png",
-        bbox_inches="tight",
-        transparent=False,
-        dpi=600,
-    )
+
+    extensions = ["png", "svg"]
+    for ext in extensions:
+        plt.savefig(
+            file_path + f"hbond_comparison.{ext}",
+            bbox_inches="tight",
+            transparent=False,
+            dpi=600,
+            format=ext, 
+        )
 
 
 def analyze_hbonds(file_paths, names, substrate):

--- a/pyqmmm/qm/orca_neb_restart.py
+++ b/pyqmmm/qm/orca_neb_restart.py
@@ -1,0 +1,98 @@
+"""Prepares a killed ORCA NEB job for a restart by moving and renaming files."""
+
+import os
+import shutil
+
+def create_delete_folder(folder_name='delete'):
+    """
+    Create a directory for files to be deleted if it doesn't already exist.
+
+    Parameters
+    ----------
+    folder_name : str, optional
+        The name of the folder where files will be moved to before deletion.
+
+    Returns
+    -------
+    None
+    """
+    if not os.path.exists(folder_name):
+        os.makedirs(folder_name)
+
+def keep_file(filename):
+    """
+    Check if a file is to be kept based on its extension or name.
+
+    Parameters
+    ----------
+    filename : str
+        The name of the file to be checked.
+
+    Returns
+    -------
+    bool
+        True if the file should be kept, False otherwise.
+    """
+    # Extensions to keep
+    keep_extensions = ['.in', '.allxyz', '.xyz', '.sh']
+    # Keep files with specific extensions or names
+    return filename.endswith(tuple(keep_extensions)) or filename.endswith(".gbw") or filename == 'delete' or filename.endswith(".py")
+
+def rename_gbw(filename):
+    """
+    Rename .gbw files if they start with "qmscript".
+
+    Parameters
+    ----------
+    filename : str
+        The name of the file to potentially rename.
+
+    Returns
+    -------
+    str
+        The new name of the file, if renamed, or the original name.
+    """
+    if filename.startswith("qmscript") and filename.endswith(".gbw"):
+        return "restart" + filename[len("qmscript"):]
+    return filename
+
+def move_files(files, delete_folder='delete'):
+    """
+    Move files to a specified folder, excluding those that are to be kept.
+
+    Parameters
+    ----------
+    files : list of str
+        The list of files in the current directory.
+    delete_folder : str, optional
+        The name of the folder to move files to.
+
+    Returns
+    -------
+    None
+    """
+    files_to_move = [f for f in files if not keep_file(f)]
+    num_files_to_move = len(files_to_move)
+
+    # Ask for user confirmation before moving files
+    response = input(f"{num_files_to_move} files will be moved to the '{delete_folder}' folder. Continue? (y/n): ")
+    if response.lower() != 'y':
+        print("Operation cancelled by user.")
+        return
+
+    for file in files_to_move:
+        shutil.move(file, os.path.join(delete_folder, file))
+        print(f"Moved: {file}")
+
+    for file in files:
+        if file.endswith(".gbw"):
+            new_name = rename_gbw(file)
+            os.rename(file, new_name)
+            print(f"Renamed: {file} to {new_name}")
+
+    print("Files have been moved or renamed as necessary, excluding specified files.")
+
+if __name__ == "__main__":
+    create_delete_folder()
+    files_in_directory = [f for f in os.listdir() if f != 'delete']
+    move_files(files_in_directory)


### PR DESCRIPTION
I added a module called orca_neb_restart. The purpose of this code is to prepare a failed/killed ORCA NEB job for restarting. This involves deleting all temporary files, renaming the the .gbw files, keeping resubmission files, and moving them to a temporary directory. This functionality can be executed with `pyqmmm qm -rneb`, where `rneb` stands for restart NEB.