### PR TITLE
Removed legend from energy plotter

### DIFF
--- a/pyqmmm/qm/energy_plotter.py
+++ b/pyqmmm/qm/energy_plotter.py
@@ -235,7 +235,6 @@ def plot_data(energies_by_file, min_first_energy, plot_relative_to_lowest):
 
     plt.xlabel("Frame number", weight="bold")
     plt.ylabel("Energy (kcal/mol)", weight="bold")
-    plt.legend()
     plot_name = "energy_plot.png"
     plt.savefig(
         plot_name,


### PR DESCRIPTION
In energy plotter the legend does not have any meaning as it is not really meant to be plotted with multiple paths. 