### PR TITLE
Legend only for multiplotting

### DIFF
--- a/pyqmmm/qm/energy_plotter.py
+++ b/pyqmmm/qm/energy_plotter.py
@@ -235,7 +235,10 @@ def plot_data(energies_by_file, min_first_energy, plot_relative_to_lowest):
 
     plt.xlabel("Frame number", weight="bold")
     plt.ylabel("Energy (kcal/mol)", weight="bold")
-    plt.legend()
+
+    # Legend is useful when plotting more than one trajectory
+    if len(energies_by_file) > 1:
+        plt.legend()
     plot_name = "energy_plot.png"
     plt.savefig(
         plot_name,


### PR DESCRIPTION
I noticed that the plotting function was always generating a legend even when there was only one trajectory. I updated it to check how many trajectories were being requested for plotting by the user.